### PR TITLE
Modify AuthenticationFailureHandler

### DIFF
--- a/securityPrj/src/main/java/tody/common/dao/UserAuthDAO.java
+++ b/securityPrj/src/main/java/tody/common/dao/UserAuthDAO.java
@@ -16,16 +16,16 @@ public class UserAuthDAO {
 		return sqlSession.selectOne("user.selectUserById", username);
 	}
 
-	public void updateFailureCount(String loginId) {
-		sqlSession.update("user.updateFailureCount", loginId);
+	public void updateFailureCount(String username) {
+		sqlSession.update("user.updateFailureCount", username);
 	}
 	
-	public int checkFailureCount(String loginId) {
-		return sqlSession.selectOne("user.checkFailureCount", loginId);
+	public int checkFailureCount(String username) {
+		return sqlSession.selectOne("user.checkFailureCount", username);
 	}
 	
-	public void updateUnenabled(String loginId) {
-		sqlSession.update("user.updateUnenabled", loginId);
+	public void updateDisabled(String username) {
+		sqlSession.update("user.updateUnenabled", username);
 	}
 
 }

--- a/securityPrj/src/main/java/tody/common/handler/LoginFailureHandler.java
+++ b/securityPrj/src/main/java/tody/common/handler/LoginFailureHandler.java
@@ -6,42 +6,18 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
-import tody.common.service.CustomUserDetailsService;
-
 public class LoginFailureHandler implements AuthenticationFailureHandler {
-	
-	@Autowired
-	private CustomUserDetailsService userDeSer;
 
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
 			throws IOException, ServletException {
 		
-		String loginId = request.getParameter("loginId");
-		String msgerror = exception.getMessage();
-		
-		if(exception instanceof BadCredentialsException) {
-			userDeSer.countFailure(loginId);	
-			int cnt = userDeSer.checkFailureCount(loginId);
-			
-			if(cnt==3) {
-				userDeSer.unenabledUsername(loginId);
-			}
-		}
-		
-		if(exception instanceof InternalAuthenticationServiceException) {
-			msgerror="아이디나 비밀번호가 맞지 않습니다. 다시 확인해주세요.";
-		}
-		
 		request.setAttribute("ID", request.getParameter("loginId"));
 		request.setAttribute("PASSWORD", request.getParameter("loginPwd"));
-		request.setAttribute("ERRORMSG", msgerror);
+		request.setAttribute("ERRORMSG",exception.getMessage());
 		request.getRequestDispatcher("/secu/loginPage?error").forward(request, response);
 	}
 

--- a/securityPrj/src/main/java/tody/common/resolver/CustomAuthenticationProvider.java
+++ b/securityPrj/src/main/java/tody/common/resolver/CustomAuthenticationProvider.java
@@ -2,6 +2,8 @@ package tody.common.resolver;
 
 import java.util.Collection;
 
+import javax.annotation.Resource;
+
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -12,11 +14,15 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
+import tody.common.service.UserService;
 import tody.common.vo.CustomUserDetails;
 
 public class CustomAuthenticationProvider implements AuthenticationProvider {
 	
 	Logger log = Logger.getLogger(getClass());
+	
+	@Resource(name="userSer")
+	private UserService userSer;
 	
 	@Autowired
 	private UserDetailsService userDeSer;
@@ -37,6 +43,11 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 		
 		if(!matchPassword(password, user.getPassword())) {
 			log.debug("matchPassword :::::::: false!");
+			userSer.countFailure(username);
+			int cnt = userSer.checkFailureCount(username);
+			if(cnt==3) {
+				userSer.disabledUsername(username);
+			}
 			throw new BadCredentialsException(username);
 		}
 		

--- a/securityPrj/src/main/java/tody/common/service/CustomUserDetailsService.java
+++ b/securityPrj/src/main/java/tody/common/service/CustomUserDetailsService.java
@@ -2,7 +2,6 @@ package tody.common.service;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,27 +18,17 @@ public class CustomUserDetailsService implements UserDetailsService {
 
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		CustomUserDetails user = userAuthDAO.getUserById(username);
 		
 		log.debug("loadUserByUsername ::::::: 2");
 		
+		CustomUserDetails user = userAuthDAO.getUserById(username);
+		
 		if(user==null) {
-			log.debug("no user :::::::: ");
-			throw new InternalAuthenticationServiceException(username);
+			log.debug("no user :::::::: AuthenticationProvider");
+			throw new UsernameNotFoundException(username);
 		}
+
 		return user;
-	}
-	
-	public void countFailure(String loginId) {
-		userAuthDAO.updateFailureCount(loginId);
-	}
-	
-	public int checkFailureCount(String loginId) {
-		return userAuthDAO.checkFailureCount(loginId);
-	}
-	
-	public void unenabledUsername(String loginId) {
-		userAuthDAO.updateUnenabled(loginId);
 	}
 
 }

--- a/securityPrj/src/main/java/tody/common/service/UserService.java
+++ b/securityPrj/src/main/java/tody/common/service/UserService.java
@@ -1,0 +1,5 @@
+package tody.common.service;
+
+public interface UserService {
+
+}

--- a/securityPrj/src/main/java/tody/common/service/UserService.java
+++ b/securityPrj/src/main/java/tody/common/service/UserService.java
@@ -2,4 +2,10 @@ package tody.common.service;
 
 public interface UserService {
 
+	void countFailure(String username);
+
+	int checkFailureCount(String username);
+
+	void disabledUsername(String username);
+
 }

--- a/securityPrj/src/main/java/tody/common/service/UserServiceImpl.java
+++ b/securityPrj/src/main/java/tody/common/service/UserServiceImpl.java
@@ -1,8 +1,30 @@
 package tody.common.service;
 
+import javax.annotation.Resource;
+
 import org.springframework.stereotype.Service;
 
-@Service("usr")
+import tody.common.dao.UserAuthDAO;
+
+@Service("userSer")
 public class UserServiceImpl implements UserService {
+	
+	@Resource(name="userAuthDAO")
+	private UserAuthDAO userDAO;
+
+	@Override
+	public void countFailure(String username) {
+		userDAO.updateFailureCount(username);
+	}
+
+	@Override
+	public int checkFailureCount(String username) {
+		return userDAO.checkFailureCount(username);
+	}
+
+	@Override
+	public void disabledUsername(String username) {
+		userDAO.updateDisabled(username);
+	}
 
 }

--- a/securityPrj/src/main/java/tody/common/service/UserServiceImpl.java
+++ b/securityPrj/src/main/java/tody/common/service/UserServiceImpl.java
@@ -1,0 +1,8 @@
+package tody.common.service;
+
+import org.springframework.stereotype.Service;
+
+@Service("usr")
+public class UserServiceImpl implements UserService {
+
+}

--- a/securityPrj/src/main/resources/spring/context-security.xml
+++ b/securityPrj/src/main/resources/spring/context-security.xml
@@ -7,7 +7,7 @@
 							http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 							http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 							
-		<context:component-scan base-package="tody.common.dao"/>
+		<context:component-scan base-package="tody.common"/>
         
 		<security:http auto-config="true" use-expressions="true">
 		    <security:intercept-url pattern="/member/**" access="hasAnyRole('ROLE_MEMBER','ROLE_ADMIN')"/>


### PR DESCRIPTION
로그인에 실패했을 때 실패한 이유를 자세히(ex. 비밀번호가 틀렸습니다, 아이디가 틀렸습니다.) 알려준다면 보안성이 낮아진다. 따라서 로그인에 실패했을 때 '아이디나 비밀번호가 맞지 않습니다.' 라는 에러 문구를 보내준다면 보안수준이 조금은 더 높아질 것이다.

실패 카운트를 늘려주는 로직을 비밀번호가 틀렸을 때 예외 로직을 던지기 전에 처리를 하자.

그리고 아이디와 비밀번호의 틀림을 구분하기 힘들다ㅠㅠ (힝)